### PR TITLE
Hotfix database string replace

### DIFF
--- a/src/data/database.php
+++ b/src/data/database.php
@@ -29,6 +29,17 @@ class  Database {
   static public function connect_execute_clean($query,$args) {
     try {
       $database = new Database();
+      // riordina le chiavi secondo l'ordine in cui sono scritte nella query
+      // e lancia un eccezzione in caso non ci sia la variabile
+      uksort($args,function ($a,$b) use($query){
+        if(($apos = strpos($query,$a)) === false){
+          throw new Exception("ERRORE: Database::connect_execute_cleanup -> $a non è contenuta nella query");
+        }
+        if(($bpos = strpos($query,$b)) === false){
+          throw new Exception("ERRORE: Database::connect_execute_cleanup -> $b non è contenuta nella query");
+        }
+        return $apos < $bpos ? 0 : 1 ;
+      });
       $offset = 0;
       foreach ($args as $name => $data) {
         [$value, $filter] = $data;
@@ -37,9 +48,6 @@ class  Database {
           throw new Exception("ERRORE: Database::connect_execute_cleanup -> il filtro ha ritornato null per $name");
         }
         $idx = strpos($query, $name, $offset);
-        if($idx === false){
-          throw new Exception("ERRORE: Database::connect_execute_cleanup -> $name non è contenuta nella query");
-        }
         $query = substr_replace($query, $replace, $idx, strlen($name));
         $offset = $idx + strlen($replace);
       }


### PR DESCRIPTION
Risolto il bug di sostituzione nella query, se i campi contengono nomi di variabili al loro interno.